### PR TITLE
Fix distro naming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,28 +12,28 @@ build: verifyimage
 	docker-compose down
 
 verifyimage:
-	@if [ ! -f "src/image/raspbian_latest-raspbian.zip" ]; \
-	then echo "Raspbian image does not exist. Starting Download..."; \
-	curl -J -L  https://downloads.raspberrypi.org/raspios_lite_armhf_latest > src/image/raspbian_latest-raspbian.zip; else \
-	echo "Raspbian image found. Starting checksum verification"; \
-	curl -J -L https://downloads.raspberrypi.org/raspios_lite_armhf_latest.sha1 > src/image/raspbian_latest-raspbian.zip.sha1; \
-	IMAGE_SHA1=`sha1sum src/image/raspbian_latest-raspbian.zip | awk '{print $$1}'`; \
-	DL_SHA1=`awk '{print $$1}' src/image/raspbian_latest-raspbian.zip.sha1`; \
+	@if [ ! -f "src/image/raspios_latest.zip" ]; \
+	then echo "Raspberry Pi OS image does not exist. Starting Download..."; \
+	curl -J -L  https://downloads.raspberrypi.org/raspios_lite_armhf_latest > src/image/raspios_latest.zip; else \
+	echo "Raspberry Pi OS image found. Starting checksum verification"; \
+	curl -J -L https://downloads.raspberrypi.org/raspios_lite_armhf_latest.sha1 > src/image/raspios_latest.zip.sha1; \
+	IMAGE_SHA1=`sha1sum src/image/raspios_latest.zip | awk '{print $$1}'`; \
+	DL_SHA1=`awk '{print $$1}' src/image/raspios_latest.zip.sha1`; \
 	if [ "$$IMAGE_SHA1" != "$$DL_SHA1" ]; then echo "SHAs do not match."; \
 	echo "Got $$IMAGE_SHA1"; echo "Expected $$DL_SHA1"; \
 	echo "Starting image download"; \
-	curl -J -L  https://downloads.raspberrypi.org/raspios_lite_armhf_latest > src/image/raspbian_latest-raspbian.zip; else echo "SHAs Matched"; fi; fi
+	curl -J -L  https://downloads.raspberrypi.org/raspios_lite_armhf_latest > src/image/raspios_latest.zip; else echo "SHAs Matched"; fi; fi
 
 clean:
 	rm -rf src/workspace
-	rm -f src/build.log
-	rm -f src/image/raspbian_latest-raspbian.zip.sha1
+	rm -f src/build.lg
+	rm -f src/image/raspios_latest.zip.sha1
 
 # dist clean should contain clean as usual
 distclean:
 	rm -rf src/workspace
 	rm -f src/build.log
-	rm -f src/image/raspbian_latest-raspbian.zip.sha1
+	rm -f src/image/raspios_latest.zip.sha1
 	rm -rf src/image/*.zip
 
 # /src/workspace is blocked by file Permissions from Docker Container and you are not building as root user

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Here a list of included and preinstalled Software:
 ## Requirements
 - [qemu-arm-static](http://packages.debian.org/sid/qemu-user-static)
 - [CustomPiOS](https://github.com/guysoft/CustomPiOS)
-- [Downloaded Raspbian Image](http://www.raspbian.org/)
+- [Downloaded Raspberry Pi OS Image](https://www.raspberrypi.com/software/operating-systems/)
 - Bash
 - Git
 - [Docker](https://docs.docker.com/engine/install/ubuntu/)
@@ -72,5 +72,5 @@ make distclean - Clean up the source image and trigger a new download
 
 ### Build layout
 MainsailOS/emulation - Contains dependencies for emulation testing  
-MainsailOS/src/image - Contains our base raspbian image  
+MainsailOS/src/image - Contains our base Raspberry Pi OS image  
 MainsailOS/src/workspace - Created during build, and output for compiled images

--- a/emulation/README.md
+++ b/emulation/README.md
@@ -2,9 +2,9 @@
 
 These images are provided by [dhruvvyas90](https://github.com/dhruvvyas90/qemu-rpi-kernel.git)
 
-Thanks for your effort to bring newer and especcialy patched for qemu Kernels!
+Thanks for your effort to bring newer and especially patched for qemu Kernels!
 
-**To match used Kernel in latest raspbian Image the**
+**To match used Kernel in latest Raspberry Pi OS Image the**
 
     make test
 

--- a/src/README.md
+++ b/src/README.md
@@ -1,4 +1,4 @@
-Build MainsailOS From within MainsailOS / OctoPi / Raspbian / Debian / Ubuntu
+Build MainsailOS From within MainsailOS / OctoPi / Raspberry Pi OS / Debian / Ubuntu
 MainsailOS can be built from Debian, Ubuntu, Raspbian, OctoPi, or even MainsailOS. Build requires about 5 GB of free space available. You can build it by issuing the following commands:
 
 sudo apt-get install gawk util-linux qemu-user-static git p7zip-full python3

--- a/src/image/README
+++ b/src/image/README
@@ -1,5 +1,5 @@
-Place zipped Rasbian image here.
+Place zipped Raspberry Pi OS image here.
 
 If not otherwise specified, the build script will always use the most
-recent zip file matching the file name pattern "*-raspbian.zip" located
+recent zip file matching the file name pattern "raspios_*.zip" located
 here.


### PR DESCRIPTION
Raspbian and Raspberry Pi OS are two different distros.  
See [this blog post](https://www.tomshardware.com/news/raspberry-pi-os-no-longer-raspbian).  
This distro uses Raspberry Pi OS as a base. This PR removes all references to Raspbian.